### PR TITLE
Elp cncf1

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -2,7 +2,8 @@
 
 [Instructions](https://contribute.cncf.io/maintainers/github/templates/required/governance-maintainer/)
 
-The KubeSlice project is dedicated to the creation and management of groups of related pods and services that communicate seamlessly across one or more clusters located in one or more clouds, edges, or data centers.  
+The KubeSlice project is dedicated to the creation and management of groups of related pods and services that communicate seamlessly across one or more clusters located in one or more clouds, edges, or data centers.
+
 This governance explains how the project is run.
 
 - [Values](#values)
@@ -96,8 +97,7 @@ and can be rapidly returned to Maintainer status if their availability changes.
 ## Meetings
 
 Time zones permitting, Maintainers are expected to participate in the public
-developer meeting, which occurs
-[TODO: Details of regular developer or maintainer meeting here].  
+developer meeting, details of which are linked at: [KubeSlice Project](https://github.com/kubeslice#woman_technologist-this-sounds-awesome-and-i-want-to-help).  
 
 Maintainers will also have closed meetings in order to discuss security reports
 or Code of Conduct violations.  Such meetings should be scheduled by any
@@ -118,7 +118,7 @@ for that purpose.
 
 [Code of Conduct](./code-of-conduct.md)
 violations by community members will be discussed and resolved
-on the [private Maintainer mailing list](kubeslice-maint@googlegroups.com).  If a Maintainer is directly involved
+on the [private Maintainer mailing list](https://groups.google.com/g/kubeslice-maint).  If a Maintainer is directly involved
 in the report, the Maintainers will instead designate two Maintainers to work
 with the CNCF Code of Conduct Committee in resolving it.
 
@@ -139,7 +139,7 @@ While most business in KubeSlice is conducted by "[lazy consensus](https://commu
 periodically the Maintainers may need to vote on specific actions or changes.
 A vote can be taken on [the developer mailing list](kubeslice-dev@googlegroups.com) or
 [the private Maintainer mailing list](kubeslice-maint@googlegroups.com) for security or conduct matters.  
-Votes may also be taken at [the developer meeting](TODO).  Any Maintainer may
+Votes may also be taken at [the developer meeting](https://github.com/kubeslice#woman_technologist-this-sounds-awesome-and-i-want-to-help).  Any Maintainer may
 demand a vote be taken.
 
 Most votes require a simple majority of all Maintainers to succeed, except where

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,152 @@
+# KubeSlice Project Governance
+
+[Instructions](https://contribute.cncf.io/maintainers/github/templates/required/governance-maintainer/)
+
+The KubeSlice project is dedicated to the creation and management of groups of related pods and services that communicate seamlessly across one or more clusters located in one or more clouds, edges, or data centers.  
+This governance explains how the project is run.
+
+- [Values](#values)
+- [Maintainers](#maintainers)
+- [Becoming a Maintainer](#becoming-a-maintainer)
+- [Meetings](#meetings)
+- [CNCF Resources](#cncf-resources)
+- [Code of Conduct Enforcement](#code-of-conduct)
+- [Security Response Team](#security-response-team)
+- [Voting](#voting)
+- [Modifications](#modifying-this-charter)
+
+## Values
+
+The KubeSlice Project and its leadership embrace the following values:
+
+* Openness: Communication and decision-making happens in the open and is discoverable for future
+  reference. As much as possible, all discussions and work take place in public
+  forums and open repositories.
+
+* Fairness: All stakeholders have the opportunity to provide feedback and submit
+  contributions, which will be considered on their merits.
+
+* Community over Product or Company: Sustaining and growing our community takes
+  priority over shipping code or sponsors' organizational goals.  Each
+  contributor participates in the project as an individual.
+
+* Inclusivity: We innovate through different perspectives and skill sets, which
+  can only be accomplished in a welcoming and respectful environment.
+
+* Participation: Responsibilities within the project are earned through
+  participation, and there is a clear path up the contributor ladder into leadership
+  positions.
+
+## Maintainers
+
+KubeSlice Maintainers have write access to the https://github.com/kubeslice repositories.
+They can merge their own patches or patches from others. The current maintainers
+can be found in [MAINTAINERS.md](./MAINTAINERS.md) in each repository that makes up KubeSlice.  Maintainers collectively manage the project's resources and contributors.
+
+This privilege is granted with some expectation of responsibility: maintainers
+are people who care about the KubeSlice project and want to help it grow and
+improve. A maintainer is not just someone who can make changes, but someone who
+has demonstrated their ability to collaborate with the team, get the most
+knowledgeable people to review code and docs, contribute high-quality code, and
+follow through to fix issues (in code or tests).
+
+A maintainer is a contributor to the project's success and a citizen helping
+the project succeed.
+
+The collective team of all Maintainers is known as the Maintainer Council, which
+is the governing body for the project.
+
+### Becoming a Maintainer
+
+To become a Maintainer you need to demonstrate the following:
+
+  * commitment to the project:
+    * participate in discussions, contributions, code and documentation reviews
+      for three months or more,
+  * ability to write quality code and/or documentation,
+  * ability to collaborate with the team,
+  * understanding of how the team works (policies, processes for testing and code review, etc),
+  * understanding of the project's code base and coding and documentation style.
+  * be recommended as a maintainer by at least two other maintainers
+
+A new Maintainer must be proposed by an existing maintainer by sending a message to the
+[# kubeslice slack channel](https://kubernetes.slack.com/archives/C03Q64HNEJF). A simple majority vote of existing Maintainers approves the application.  Maintainers nominations will be evaluated without prejudice
+to employer or demographics.
+
+Maintainers who are selected will be granted the necessary GitHub rights,
+and invited to the [private maintainer mailing list](TODO).
+
+### Removing a Maintainer
+
+Maintainers may resign at any time if they feel that they will not be able to
+continue fulfilling their project duties.
+
+Maintainers may also be removed after being inactive, failure to fulfill their 
+Maintainer responsibilities, violating the Code of Conduct, or other reasons.
+Inactivity is defined as a period of very low or no activity in the project 
+for a year or more, with no definite schedule to return to full Maintainer 
+activity.
+
+A Maintainer may be removed at any time by a 2/3 vote of the remaining maintainers.
+
+Depending on the reason for removal, a Maintainer may be converted to Emeritus
+status.  Emeritus Maintainers will still be consulted on some project matters,
+and can be rapidly returned to Maintainer status if their availability changes.
+
+## Meetings
+
+Time zones permitting, Maintainers are expected to participate in the public
+developer meeting, which occurs
+[TODO: Details of regular developer or maintainer meeting here].  
+
+Maintainers will also have closed meetings in order to discuss security reports
+or Code of Conduct violations.  Such meetings should be scheduled by any
+Maintainer on receipt of a security issue or CoC report.  All current Maintainers
+must be invited to such closed meetings, except for any Maintainer who is
+accused of a CoC violation.
+
+## CNCF Resources
+
+Any Maintainer may suggest a request for CNCF resources, either in the
+[mailing list](TODO: link to developer/maintainer mailing list), or during a
+meeting.  A simple majority of Maintainers approves the request.  The Maintainers
+may also choose to delegate working with the CNCF to non-Maintainer community
+members, who will then be added to the [CNCF's Maintainer List](https://github.com/cncf/foundation/blob/main/project-maintainers.csv)
+for that purpose.
+
+## Code of Conduct
+
+[Code of Conduct](./code-of-conduct.md)
+violations by community members will be discussed and resolved
+on the [private Maintainer mailing list](TODO).  If a Maintainer is directly involved
+in the report, the Maintainers will instead designate two Maintainers to work
+with the CNCF Code of Conduct Committee in resolving it.
+
+## Security Response Team
+
+The Maintainers will appoint a Security Response Team to handle security reports.
+This committee may simply consist of the Maintainer Council themselves.  If this
+responsibility is delegated, the Maintainers will appoint a team of at least two 
+contributors to handle it.  The Maintainers will review who is assigned to this
+at least once a year.
+
+The Security Response Team is responsible for handling all reports of security
+holes and breaches according to the [security policy](TODO:Link to security.md).
+
+## Voting
+
+While most business in [TODO: PROJECTNAME] is conducted by "[lazy consensus](https://community.apache.org/committers/lazyConsensus.html)", 
+periodically the Maintainers may need to vote on specific actions or changes.
+A vote can be taken on [the developer mailing list](TODO) or
+[the private Maintainer mailing list](TODO) for security or conduct matters.  
+Votes may also be taken at [the developer meeting](TODO).  Any Maintainer may
+demand a vote be taken.
+
+Most votes require a simple majority of all Maintainers to succeed, except where
+otherwise noted.  Two-thirds majority votes mean at least two-thirds of all 
+existing maintainers.
+
+## Modifying this Charter
+
+Changes to this Governance and its supporting documents may be approved by 
+a 2/3 vote of the Maintainers.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -74,7 +74,7 @@ A new Maintainer must be proposed by an existing maintainer by sending a message
 to employer or demographics.
 
 Maintainers who are selected will be granted the necessary GitHub rights,
-and invited to the [private maintainer mailing list](TODO).
+and invited to the [private maintainer mailing list](kubeslice-maint@googlegroups.com) mailing list.
 
 ### Removing a Maintainer
 
@@ -108,17 +108,17 @@ accused of a CoC violation.
 ## CNCF Resources
 
 Any Maintainer may suggest a request for CNCF resources, either in the
-[mailing list](TODO: link to developer/maintainer mailing list), or during a
-meeting.  A simple majority of Maintainers approves the request.  The Maintainers
-may also choose to delegate working with the CNCF to non-Maintainer community
-members, who will then be added to the [CNCF's Maintainer List](https://github.com/cncf/foundation/blob/main/project-maintainers.csv)
+[developer mailing list](kubeslice-dev@googlegroups.com), or during a meeting.  A simple
+majority of Maintainers approves the request.  The Maintainers may also choose
+to delegate working with the CNCF to non-Maintainer community members, who
+will then be added to the [CNCF's Maintainer List](https://github.com/cncf/foundation/blob/main/project-maintainers.csv)
 for that purpose.
 
 ## Code of Conduct
 
 [Code of Conduct](./code-of-conduct.md)
 violations by community members will be discussed and resolved
-on the [private Maintainer mailing list](TODO).  If a Maintainer is directly involved
+on the [private Maintainer mailing list](kubeslice-maint@googlegroups.com).  If a Maintainer is directly involved
 in the report, the Maintainers will instead designate two Maintainers to work
 with the CNCF Code of Conduct Committee in resolving it.
 
@@ -131,14 +131,14 @@ contributors to handle it.  The Maintainers will review who is assigned to this
 at least once a year.
 
 The Security Response Team is responsible for handling all reports of security
-holes and breaches according to the [security policy](TODO:Link to security.md).
+holes and breaches according to the [security policy](https://github.com/kubeslice/kubeslice/blob/master/SECURITY.md).
 
 ## Voting
 
-While most business in [TODO: PROJECTNAME] is conducted by "[lazy consensus](https://community.apache.org/committers/lazyConsensus.html)", 
+While most business in KubeSlice is conducted by "[lazy consensus](https://community.apache.org/committers/lazyConsensus.html)", 
 periodically the Maintainers may need to vote on specific actions or changes.
-A vote can be taken on [the developer mailing list](TODO) or
-[the private Maintainer mailing list](TODO) for security or conduct matters.  
+A vote can be taken on [the developer mailing list](kubeslice-dev@googlegroups.com) or
+[the private Maintainer mailing list](kubeslice-maint@googlegroups.com) for security or conduct matters.  
 Votes may also be taken at [the developer meeting](TODO).  Any Maintainer may
 demand a vote be taken.
 


### PR DESCRIPTION
Added a KubeSlice version of the GOVERNANCE template (with associated community mailing lists and meetings).