### PR TITLE
fix(ServiceExport): Add validating webhook template for serviceexport object

### DIFF
--- a/charts/kubeslice-worker/templates/webhook.yaml
+++ b/charts/kubeslice-worker/templates/webhook.yaml
@@ -74,3 +74,49 @@ webhooks:
       - spire
       - {{ .Release.Namespace | quote }}
       - {{ .Values.controllerNamespace | quote }}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: kubeslice-validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    caBundle: {{ $ca.Cert | b64enc }}
+    service:
+      name: kubeslice-webhook-service
+      namespace: {{ .Release.Namespace }}
+      path: /validate-webhook
+  failurePolicy: Fail
+  name: webhook.kubeslice.io
+  rules:
+  - apiGroups:
+    - networking.kubeslice.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - serviceexports
+  sideEffects: NoneOnDryRun
+  namespaceSelector:
+    matchExpressions:
+    - key: kubeslice.io/slice
+      operator: Exists
+    - key: name
+      operator: NotIn
+      values:
+      - kube-system
+      - spire
+      - {{ .Release.Namespace | quote}}
+      - {{ .Values.controllerNamespace | quote }}
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - spire
+      - {{ .Release.Namespace | quote }}
+      - {{ .Values.controllerNamespace | quote }}


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below-mentioned types:

- docs() - The PR contains Documentation ONLY changes. 
- feat() - The PR contains new feature/enhancements.
- fix() - The PR contains a bug fix.
- chore() - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test() - Development changes related to tests.
- perf() - Changes related to performance improvements.

Example Title: 
feat(): New field addition for Cluster CRD 
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
Validating webhook for service export object has been introduced in this https://github.com/kubeslice/worker-operator/pull/337 and is merged now. This PR adds the respective template for validating webhook configuration.

Fixes #

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
<!--test-cases
- [ ] Test case A
- [ ] Test case B
-->

## Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit test cases.

## Does this PR introduce a breaking change for other components like worker-operator?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

## [optional] What gif best describes this PR or how it makes you feel?

![WoW](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExMmV3dmxidWpiN2Jlb21rOGNjcXZhemN4bGR0cHBpNW1rd2w4dW9haSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/tIeCLkB8geYtW/giphy.gif)
