### PR TITLE
fix: Add default resource specifications to netop sidecar container

### DIFF
--- a/charts/kubeslice-worker/charts/netop/ci/test-values-default-resources.yaml
+++ b/charts/kubeslice-worker/charts/netop/ci/test-values-default-resources.yaml
@@ -1,6 +1,6 @@
 # Test values file for netop chart - Default Resources Test
 # Purpose: Test that default resource values are applied when resources section is not specified
-# Usage: helm template test . -f tests/test-values-default-resources.yaml
+# Usage: helm template test . -f ci/test-values-default-resources.yaml
 # Expected: Should render with default resource values from main values.yaml (CPU: 100m/200m, Memory: 128Mi/256Mi)
 
 global:

--- a/charts/kubeslice-worker/charts/netop/templates/mesh-netop.yaml
+++ b/charts/kubeslice-worker/charts/netop/templates/mesh-netop.yaml
@@ -36,6 +36,10 @@ spec:
         image: '{{ .Values.global.imageRegistry }}/{{ .Values.netop.image }}:{{ .Values.netop.tag }}'
         imagePullPolicy: {{ .Values.netop.pullPolicy }}
         name: avesha-sidecar
+        {{- with .Values.netop.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         securityContext:
           allowPrivilegeEscalation: true
           capabilities:

--- a/charts/kubeslice-worker/charts/netop/tests/test-values-default-resources.yaml
+++ b/charts/kubeslice-worker/charts/netop/tests/test-values-default-resources.yaml
@@ -1,0 +1,14 @@
+# Test values file for netop chart - Default Resources Test
+# Purpose: Test that default resource values are applied when resources section is not specified
+# Usage: helm template test . -f tests/test-values-default-resources.yaml
+# Expected: Should render with default resource values from main values.yaml (CPU: 100m/200m, Memory: 128Mi/256Mi)
+
+global:
+  netop_docker_existingImagePullSecret: "kubeslice-image-pull-secret"
+  imageRegistry: docker.io/aveshasystems
+netop:
+  networkInterface: eth0
+  image: netops
+  tag: 0.2.2 
+  pullPolicy: IfNotPresent
+  # Note: resources section is omitted to test that default values are applied

--- a/charts/kubeslice-worker/charts/netop/values.yaml
+++ b/charts/kubeslice-worker/charts/netop/values.yaml
@@ -13,3 +13,10 @@ netop:
   image: netops
   tag: 0.2.2 
   pullPolicy: IfNotPresent
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below-mentioned types:

- docs() - The PR contains Documentation ONLY changes. 
- feat() - The PR contains new feature/enhancements.
- fix() - The PR contains a bug fix.
- chore() - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test() - Development changes related to tests.
- perf() - Changes related to performance improvements.

Example Title: 
feat(): New field addition for Cluster CRD 
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Added default resource specifications to netop sidecar container (`avesha-sidecar`) to resolve missing resource requests and limits that could cause scheduling and resource contention issues.

Fixes #38

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
<!--test-cases
- [ ] Test case A
- [ ] Test case B
-->

- [x] Helm template rendering with default values
- [x] Helm template rendering with custom resource values 
- [x] Default resource values applied when resources section is omitted

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [x] I have tested it for all user roles.
* [x] I have added all the required unit test cases.

## Does this PR introduce a breaking change for other components like worker-operator?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

## [optional] What gif best describes this PR or how it makes you feel?

![WoW](https://media1.tenor.com/m/IibUHHYqyLYAAAAd/touch-me-just-a-chill-guy.gif)
