### PR TITLE
chore(): Remove depreciated kubebuilder/kube-rbac-proxy container and use default metrics endpoint

### DIFF
--- a/charts/kubeslice-worker/templates/operator-deployment.yaml
+++ b/charts/kubeslice-worker/templates/operator-deployment.yaml
@@ -23,17 +23,6 @@ spec:
     spec:
       containers:
       - args:
-        - --secure-listen-address=0.0.0.0:8443
-        - --upstream=http://127.0.0.1:8080/
-        - --logtostderr=true
-        - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
-        name: kube-rbac-proxy
-        ports:
-        - containerPort: 8443
-          name: https
-          protocol: TCP
-      - args:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=:8080
         - --leader-elect


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below-mentioned types:

- docs() - The PR contains Documentation ONLY changes. 
- feat() - The PR contains new feature/enhancements.
- fix() - The PR contains a bug fix.
- chore() - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test() - Development changes related to tests.
- perf() - Changes related to performance improvements.

Example Title: 
feat(): New field addition for Cluster CRD 
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
This PR does the following changes:
- Remove deprecated `kube-rbac-proxy` sidecar container
- Modernize to use controller-runtime's built-in metrics capabilities
- Reduce resource consumption

Right now, PR implements `http` metrics endpoint for simplicity. Still, it is not a security issue because the metrics endpoint is used by `prometheus` only internally within the cluster itself.

But, for more security( if needed ), we can implement `https` version of metrics server; for that, we need to make changes in `worker operator` `main.go` file to use secured version and set up certificates as well. This can be done in a follow-up PR if needed.

Fixes #52 

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
<!--test-cases
- [ ] Test case A
- [ ] Test case B
-->
Tested with::
`helm lint` and `helm install <release-name> <chart-path> --dry-run=server`.
Showed no error.

## Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit test cases.

## Does this PR introduce a breaking change for other components like worker-operator?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```
