### PR TITLE
fix(): Add pod level security context for kubeslice-worker pod

### DIFF
--- a/charts/kubeslice-worker/templates/operator-deployment.yaml
+++ b/charts/kubeslice-worker/templates/operator-deployment.yaml
@@ -119,6 +119,8 @@ spec:
             readOnly: true
       serviceAccountName: kubeslice-controller-manager
       terminationGracePeriodSeconds: 10
+      securityContext:
+        {{- toYaml .Values.operator.securityContext | nindent 8 }}
       volumes:
         - name: kubeslice-worker-event-schema-conf
           configMap:

--- a/charts/kubeslice-worker/values.yaml
+++ b/charts/kubeslice-worker/values.yaml
@@ -4,6 +4,13 @@ operator:
   logLevel: INFO
   tag: 1.4.0
 
+  # Add security-context for worker-operator pod
+  securityContext:
+    runAsUser: 65534
+    runAsNonRoot: true
+    runAsGroup: 65534
+    fsGroup: 65534
+
 ## Base64 encoded secret values from controller cluster
 controllerSecret:
   namespace:


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below-mentioned types:

- docs() - The PR contains Documentation ONLY changes. 
- feat() - The PR contains new feature/enhancements.
- fix() - The PR contains a bug fix.
- chore() - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test() - Development changes related to tests.
- perf() - Changes related to performance improvements.

Example Title: 
feat(): New field addition for Cluster CRD 
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
This PR updates `kubeslice-worker` chart to add pod level security context for `kubeslice`  worker-operator pod, enhancing security posture of operator.

Fixes #35 

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
<!--test-cases
- [ ] Test case A
- [ ] Test case B
-->
I have tested with `helm lint <chart-name>` and `helm install ... ` command to ensure that chart is functional after the change.

## Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit test cases.

## Does this PR introduce a breaking change for other components like worker-operator?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```