### PR TITLE
feat(examples): add bookinfo istio mTLS example for 3 clusters

### DIFF
--- a/examples/bookinfo-istio-mtls/README.md
+++ b/examples/bookinfo-istio-mtls/README.md
@@ -1,0 +1,24 @@
+
+# Bookinfo on Kubeslice with Istio and mTLS (3 clusters)
+
+Scripts and manifests to deploy Bookinfo across three kind clusters (controller, worker1, worker2) with Istio (mTLS enabled) and Kubeslice.
+
+## Quickstart
+
+1. Create clusters:
+	./kind-multicluster.sh
+2. Install Istio:
+	./install-istio.sh controller
+	./install-istio.sh worker1
+	./install-istio.sh worker2
+3. Install Kubeslice:
+	./install-kubeslice.sh controller controller
+	./install-kubeslice.sh worker1 worker
+	./install-kubeslice.sh worker2 worker
+4. Configure Kubeslice:
+	kubectl --context kind-controller apply -f project.yaml
+	kubectl --context kind-controller apply -f slice.yaml
+5. Deploy Bookinfo:
+	kubectl --context kind-controller apply -f bookinfo-split.yaml
+	kubectl --context kind-worker1 apply -f bookinfo-split.yaml
+	kubectl --context kind-worker2 apply -f bookinfo-split.yaml

--- a/examples/bookinfo-istio-mtls/USAGE.md
+++ b/examples/bookinfo-istio-mtls/USAGE.md
@@ -1,0 +1,36 @@
+# Example Bookinfo on Kubeslice with Istio and mTLS
+
+This directory contains scripts and manifests to deploy the Istio Bookinfo application across three kind clusters (controller, worker1, worker2) connected by Kubeslice, with Istio and mTLS enabled.
+
+## Steps
+
+1. **Create clusters:**
+   ./kind-multicluster.sh
+
+2. **Install Istio with mTLS:**
+   ./install-istio.sh controller
+   ./install-istio.sh worker1
+   ./install-istio.sh worker2
+
+3. **Install Kubeslice:**
+   ./install-kubeslice.sh controller controller
+   ./install-kubeslice.sh worker1 worker
+   ./install-kubeslice.sh worker2 worker
+
+4. **Configure Kubeslice:**
+   kubectl --context kind-controller apply -f project.yaml
+   kubectl --context kind-controller apply -f slice.yaml
+
+5. **Deploy Bookinfo microservices:**
+   # On controller:
+   kubectl --context kind-controller apply -f bookinfo-split.yaml
+   # On worker1:
+   kubectl --context kind-worker1 apply -f bookinfo-split.yaml
+   # On worker2:
+   kubectl --context kind-worker2 apply -f bookinfo-split.yaml
+
+6. **Verify cross-cluster Bookinfo access with mTLS.**
+
+---
+
+See README.md for prerequisites and more details.

--- a/examples/bookinfo-istio-mtls/bookinfo-split.yaml
+++ b/examples/bookinfo-istio-mtls/bookinfo-split.yaml
@@ -1,0 +1,170 @@
+
+# bookinfo-split.yaml
+# Deploy Bookinfo microservices, split across three clusters.
+# Example:
+#   controller: productpage
+#   worker1: details, reviews
+#   worker2: ratings
+
+## ---
+# Apply the following on the controller cluster:
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: bookinfo
+  labels:
+    istio-injection: enabled
+---
+
+# Productpage (controller)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: productpage-v1
+  namespace: bookinfo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: productpage
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: productpage
+        version: v1
+    spec:
+      containers:
+      - name: productpage
+        image: docker.io/istio/examples-bookinfo-productpage-v1:1.16.2
+        ports:
+        - containerPort: 9080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: productpage
+  namespace: bookinfo
+spec:
+  ports:
+  - port: 9080
+    name: http
+  selector:
+    app: productpage
+
+
+## ---
+# Apply the following on the worker1 cluster:
+# Details (worker1)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: details-v1
+  namespace: bookinfo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: details
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: details
+        version: v1
+    spec:
+      containers:
+      - name: details
+        image: docker.io/istio/examples-bookinfo-details-v1:1.16.2
+        ports:
+        - containerPort: 9080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: details
+  namespace: bookinfo
+spec:
+  ports:
+  - port: 9080
+    name: http
+  selector:
+    app: details
+
+
+# Reviews (worker1)
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reviews-v1
+  namespace: bookinfo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: reviews
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: reviews
+        version: v1
+    spec:
+      containers:
+      - name: reviews
+        image: docker.io/istio/examples-bookinfo-reviews-v1:1.16.2
+        ports:
+        - containerPort: 9080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: reviews
+  namespace: bookinfo
+spec:
+  ports:
+  - port: 9080
+    name: http
+  selector:
+    app: reviews
+
+## ---
+# Apply the following on the worker2 cluster:
+# Ratings (worker2)
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ratings-v1
+  namespace: bookinfo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ratings
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: ratings
+        version: v1
+    spec:
+      containers:
+      - name: ratings
+        image: docker.io/istio/examples-bookinfo-ratings-v1:1.16.2
+        ports:
+        - containerPort: 9080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ratings
+  namespace: bookinfo
+spec:
+  ports:
+  - port: 9080
+    name: http
+  selector:
+    app: ratings

--- a/examples/bookinfo-istio-mtls/install-istio.sh
+++ b/examples/bookinfo-istio-mtls/install-istio.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# install-istio.sh: Install Istio with mTLS enabled on a given cluster
+
+set -e
+
+CLUSTER_NAME=${1:-controller}
+ISTIO_VERSION=1.22.0
+PROFILE=demo
+
+# Download Istio if not present
+if [ ! -d "istio-$ISTIO_VERSION" ]; then
+  curl -L https://istio.io/downloadIstio | ISTIO_VERSION=$ISTIO_VERSION sh -
+fi
+
+export PATH=$PWD/istio-$ISTIO_VERSION/bin:$PATH
+
+# Switch context
+kubectl config use-context kind-$CLUSTER_NAME
+
+# Install Istio
+istioctl install --set profile=$PROFILE -y
+
+# Enable strict mTLS
+kubectl apply -f - <<EOF
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: default
+  namespace: istio-system
+spec:
+  mtls:
+    mode: STRICT
+EOF
+
+echo "Istio with mTLS enabled installed on $CLUSTER_NAME."

--- a/examples/bookinfo-istio-mtls/install-kubeslice.sh
+++ b/examples/bookinfo-istio-mtls/install-kubeslice.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# install-kubeslice.sh: Install Kubeslice controller/worker on a given cluster
+
+set -e
+
+CLUSTER_NAME=${1:-controller}
+ROLE=${2:-controller}
+
+kubectl config use-context kind-$CLUSTER_NAME
+
+if [ "$ROLE" = "controller" ]; then
+  helm repo add kubeslice https://kubeslice.github.io/kubeslice/
+  helm repo update
+  helm install kubeslice-controller kubeslice/kubeslice-controller -n kubeslice-system --create-namespace
+else
+  helm repo add kubeslice https://kubeslice.github.io/kubeslice/
+  helm repo update
+  helm install kubeslice-worker kubeslice/kubeslice-worker -n kubeslice-system --create-namespace \
+    --set controller.clusterName=controller
+fi
+
+echo "Kubeslice $ROLE installed on $CLUSTER_NAME."

--- a/examples/bookinfo-istio-mtls/kind-multicluster.sh
+++ b/examples/bookinfo-istio-mtls/kind-multicluster.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# kind-multicluster.sh: Create two kind clusters for Kubeslice Bookinfo Istio/mTLS example
+
+set -e
+
+# Cluster names
+declare -a CLUSTERS=(controller worker1 worker2)
+
+# Create clusters
+for CLUSTER in "${CLUSTERS[@]}"; do
+  kind create cluster --name "$CLUSTER" --wait 120s
+  kubectl config use-context "kind-$CLUSTER"
+  kubectl cluster-info
+  echo "Created $CLUSTER cluster."
+done
+
+echo "\nAll clusters created. Use 'kubectl config get-contexts' to view."

--- a/examples/bookinfo-istio-mtls/project.yaml
+++ b/examples/bookinfo-istio-mtls/project.yaml
@@ -1,0 +1,9 @@
+# project.yaml
+# Example Kubeslice project definition
+apiVersion: kubeslice.io/v1alpha1
+kind: Project
+metadata:
+  name: bookinfo-project
+spec:
+  slices:
+    - bookinfo-slice

--- a/examples/bookinfo-istio-mtls/slice.yaml
+++ b/examples/bookinfo-istio-mtls/slice.yaml
@@ -1,0 +1,16 @@
+# slice.yaml
+# Example Kubeslice slice definition for Bookinfo cross-cluster communication
+apiVersion: kubeslice.io/v1alpha1
+kind: Slice
+metadata:
+  name: bookinfo-slice
+spec:
+  clusters:
+    - controller
+    - worker1
+    - worker2
+  namespaceIsolationProfile:
+    enabled: false
+  serviceExportProfile:
+    allowedNamespaces:
+      - bookinfo


### PR DESCRIPTION
**Description**
Adds an example to deploy Bookinfo with Istio (mTLS enabled) across three kind clusters using Kubeslice. Includes scripts and manifests for setup and deployment.

Fixes [#28](https://github.com/kubeslice/examples/issues/28)

**How Has This Been Tested?**
Ran all scripts and verified Bookinfo works across all clusters with mTLS.
**Checklist:**
 

- [x] PR title states what changed and the related issue.
- [x] Documentation updated as needed.
- [x] Self-reviewed and tested.