### PR TITLE
feat(helm): Add Dynamic IPAM support with SliceIpam CRD

### DIFF
--- a/charts/kubeslice-controller/Chart.yaml
+++ b/charts/kubeslice-controller/Chart.yaml
@@ -29,5 +29,5 @@ keywords:
 - application
 kubeVersion: '>= 1.19.0-0'
 home: https://avesha.io/products/product-slice
-version: 1.4.0
+version: 1.5.0
 appVersion: 1.4.0

--- a/charts/kubeslice-controller/templates/kubeslice-controller.yaml
+++ b/charts/kubeslice-controller/templates/kubeslice-controller.yaml
@@ -589,6 +589,7 @@ spec:
                 enum:
                 - Static
                 - Dynamic
+                - Local
                 type: string
               sliceSubnet:
                 type: string
@@ -1274,6 +1275,7 @@ spec:
                 enum:
                 - Static
                 - Dynamic
+                - Local
                 type: string
               sliceName:
                 type: string

--- a/charts/kubeslice-controller/templates/kubeslice-controller.yaml
+++ b/charts/kubeslice-controller/templates/kubeslice-controller.yaml
@@ -370,8 +370,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: sliceconfigs.controller.kubeslice.io
 spec:
   group: controller.kubeslice.io
@@ -388,14 +387,19 @@ spec:
         description: SliceConfig is the Schema for the sliceconfig API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -424,6 +428,7 @@ spec:
                       enum:
                       - none
                       - istio
+                      - envoy
                       type: string
                     ingress:
                       properties:
@@ -434,6 +439,19 @@ spec:
                       properties:
                         enabled:
                           type: boolean
+                      type: object
+                    vpcServiceAccess:
+                      properties:
+                        egress:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        ingress:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
                       type: object
                   type: object
                 type: array
@@ -558,13 +576,19 @@ spec:
                     type: array
                   sliceGatewayType:
                     default: OpenVPN
+                    enum:
+                    - OpenVPN
+                    - Wireguard
                     type: string
                 required:
                 - sliceCaType
                 - sliceGatewayType
                 type: object
               sliceIpamType:
-                default: Local
+                default: Static
+                enum:
+                - Static
+                - Dynamic
                 type: string
               sliceSubnet:
                 type: string
@@ -631,6 +655,149 @@ spec:
                   - event
                   type: object
                 type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: sliceipams.controller.kubeslice.io
+spec:
+  group: controller.kubeslice.io
+  names:
+    kind: SliceIpam
+    listKind: SliceIpamList
+    plural: sliceipams
+    singular: sliceipam
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.sliceName
+      name: Slice Name
+      type: string
+    - jsonPath: .spec.sliceSubnet
+      name: Slice Subnet
+      type: string
+    - jsonPath: .spec.subnetSize
+      name: Subnet Size
+      type: integer
+    - jsonPath: .status.availableSubnets
+      name: Available Subnets
+      type: integer
+    - jsonPath: .status.totalSubnets
+      name: Total Subnets
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: SliceIpam is the Schema for the sliceipams API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SliceIpamSpec defines the desired state of SliceIpam
+            properties:
+              sliceName:
+                description: SliceName is the name of the slice for which IPAM is
+                  being managed
+                minLength: 1
+                type: string
+              sliceSubnet:
+                description: SliceSubnet is the CIDR block allocated to the slice
+                pattern: ^([0-9]{1,3}\.){3}[0-9]{1,3}\/([0-9]|[1-2][0-9]|3[0-2])$
+                type: string
+              subnetSize:
+                default: 24
+                description: SubnetSize defines the size of subnets to be allocated
+                  to clusters
+                maximum: 30
+                minimum: 16
+                type: integer
+            required:
+            - sliceName
+            - sliceSubnet
+            type: object
+          status:
+            description: SliceIpamStatus defines the observed state of SliceIpam
+            properties:
+              allocatedSubnets:
+                description: AllocatedSubnets contains the list of subnet allocations
+                  for clusters
+                items:
+                  description: ClusterSubnetAllocation represents the subnet allocation
+                    for a specific cluster
+                  properties:
+                    allocatedAt:
+                      description: AllocatedAt is the timestamp when the subnet was
+                        allocated
+                      format: date-time
+                      type: string
+                    clusterName:
+                      description: ClusterName is the name of the cluster
+                      type: string
+                    releasedAt:
+                      description: ReleasedAt is the timestamp when the subnet was
+                        released (only set when status="Released")
+                      format: date-time
+                      type: string
+                    status:
+                      default: Allocated
+                      description: Status represents the current status of the subnet
+                        allocation
+                      enum:
+                      - Allocated
+                      - InUse
+                      - Released
+                      type: string
+                    subnet:
+                      description: Subnet is the CIDR block allocated to the cluster
+                      pattern: ^([0-9]{1,3}\.){3}[0-9]{1,3}\/([0-9]|[1-2][0-9]|3[0-2])$
+                      type: string
+                  required:
+                  - allocatedAt
+                  - clusterName
+                  - subnet
+                  type: object
+                type: array
+              availableSubnets:
+                description: AvailableSubnets is the number of available subnets that
+                  can be allocated
+                type: integer
+              lastUpdated:
+                description: LastUpdated is the timestamp when the status was last
+                  updated
+                format: date-time
+                type: string
+              totalSubnets:
+                description: TotalSubnets is the total number of subnets that can
+                  be created from the slice subnet
+                type: integer
+            required:
+            - availableSubnets
             type: object
         type: object
     served: true
@@ -947,8 +1114,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: workersliceconfigs.worker.kubeslice.io
 spec:
   group: worker.kubeslice.io
@@ -965,14 +1131,19 @@ spec:
         description: WorkerSliceConfig is the Schema for the slice API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -992,6 +1163,7 @@ spec:
                     enum:
                     - none
                     - istio
+                    - envoy
                     type: string
                   ingress:
                     properties:
@@ -1002,6 +1174,19 @@ spec:
                     properties:
                       enabled:
                         type: boolean
+                    type: object
+                  vpcServiceAccess:
+                    properties:
+                      egress:
+                        properties:
+                          enabled:
+                            type: boolean
+                        type: object
+                      ingress:
+                        properties:
+                          enabled:
+                            type: boolean
+                        type: object
                     type: object
                 type: object
               ipamClusterOctet:
@@ -1085,7 +1270,10 @@ spec:
                     type: string
                 type: object
               sliceIpamType:
-                default: Local
+                default: Static
+                enum:
+                - Static
+                - Dynamic
                 type: string
               sliceName:
                 type: string
@@ -1515,6 +1703,7 @@ rules:
   - projects
   - serviceexportconfigs
   - sliceconfigs
+  - sliceipams
   - sliceqosconfigs
   - vpnkeyrotations
   verbs:
@@ -1532,6 +1721,7 @@ rules:
   - projects/finalizers
   - serviceexportconfigs/finalizers
   - sliceconfigs/finalizers
+  - sliceipams/finalizers
   - sliceqosconfigs/finalizers
   - vpnkeyrotations/finalizers
   verbs:
@@ -1543,6 +1733,7 @@ rules:
   - projects/status
   - serviceexportconfigs/status
   - sliceconfigs/status
+  - sliceipams/status
   - sliceqosconfigs/status
   - vpnkeyrotations/status
   verbs:


### PR DESCRIPTION
# Description

This PR updates the kubeslice-controller Helm chart to support the Dynamic IPAM feature by adding the new `SliceIpam` CRD and updating existing CRDs with `sliceIpamType` field modifications.

**Changes:**

- **NEW:** Added `SliceIpam` CRD definition to `kubeslice-controller.yaml`
- **UPDATED:** Modified `SliceConfig` CRD - changed `sliceIpamType` field (default: Static, enum: Local/Static/Dynamic)
- **UPDATED:** Modified `WorkerSliceConfig` CRD - changed `sliceIpamType` field (default: Static, enum: Local/Static/Dynamic)
- **UPDATED:** Added RBAC permissions for `sliceipams` resource
- **UPDATED:** Chart version from 1.4.0 to 1.5.0

**Related PR:**

- kubeslice-controller: https://github.com/kubeslice/kubeslice-controller/pull/284

Fixes # (Dynamic IPAM Implementation)

## How Has This Been Tested?

Tested in local Minikube cluster (Kubernetes v1.33.1) with comprehensive validation:

- [x] Helm lint passes without errors
- [x] Helm chart installs successfully (version 1.5.0)
- [x] All 11 CRDs installed correctly (including new SliceIpam CRD)
- [x] SliceIpam CRD custom printer columns work correctly
- [x] SliceConfig CRD has updated sliceIpamType field with enum validation (Local/Static/Dynamic)
- [x] WorkerSliceConfig CRD has updated sliceIpamType field with enum validation (Local/Static/Dynamic)
- [x] RBAC permissions include sliceipams resource operations
- [x] Test SliceIpam resource created successfully
- [x] Schema validation working (CIDR patterns, field constraints)

**Test Results:** See `HELM_CHART_TEST_RESULTS.md` for detailed validation

## Checklist:

- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [x] Does this PR requires documentation updates?
- [x] I've updated documentation as required by this PR.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have tested it for all user roles.
- [x] I have added all the required unit test cases.

## Does this PR introduce a breaking change for other components like worker-operator?

**NO** - This PR is fully backward compatible. The `sliceIpamType` enum includes "Local" (for existing slices), "Static" (default for new slices), and "Dynamic" (opt-in for new feature). Existing slices with `sliceIpamType: Local` will continue to work without schema validation failures.

```release-note

```

## [optional] What gif best describes this PR or how it makes you feel?

![Dynamic IPAM](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExMmV3dmxidWpiN2Jlb21rOGNjcXZhemN4bGR0cHBpNW1rd2w4dW9haSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/tIeCLkB8geYtW/giphy.gif)
