### PR TITLE
 fix: replace hardcoded kubeslice-system namespace in worker chart templates

### DIFF
--- a/charts/kubeslice-worker/templates/dashboard-rbac.yaml
+++ b/charts/kubeslice-worker/templates/dashboard-rbac.yaml
@@ -17,7 +17,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kubeslice-kubernetes-dashboard
-  namespace: kubeslice-system
+  namespace: {{ .Release.Namespace }}
 secrets:
   - name: kubeslice-kubernetes-dashboard-creds
 ---
@@ -32,7 +32,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: kubeslice-kubernetes-dashboard
-    namespace: kubeslice-system
+    namespace: {{ .Release.Namespace }}
 ---
 apiVersion: v1
 kind: Secret

--- a/charts/kubeslice-worker/templates/hub-secret.yaml
+++ b/charts/kubeslice-worker/templates/hub-secret.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: kubeslice-hub
-  namespace: kubeslice-system 
+  namespace: {{ .Release.Namespace }}
 {{- with .Values.controllerSecret }}
 data:
  {{- toYaml . | nindent 2 }}

--- a/charts/kubeslice-worker/templates/kubeslice-postdelete-hook.yaml
+++ b/charts/kubeslice-worker/templates/kubeslice-postdelete-hook.yaml
@@ -83,7 +83,7 @@ metadata:
 data:
   kubeslice-cleanup.sh: |-
     #!/usr/bin/env bash
-    NAMESPACES=(spire kubeslice-system)
+    NAMESPACES=(spire {{ .Release.Namespace }})
     for ns in ${NAMESPACES[@]}
     do
       kubectl get ns $ns -o name  

--- a/charts/kubeslice-worker/templates/operator-configmap.yaml
+++ b/charts/kubeslice-worker/templates/operator-configmap.yaml
@@ -15,4 +15,4 @@ data:
 kind: ConfigMap
 metadata:
   name: kubeslice-manager-config
-  namespace: kubeslice-system
+  namespace: {{ .Release.Namespace }}

--- a/charts/kubeslice-worker/templates/operator-deployment.yaml
+++ b/charts/kubeslice-worker/templates/operator-deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     control-plane: controller-manager
   name: kubeslice-operator
-  namespace: kubeslice-system
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   selector:
@@ -165,5 +165,5 @@ metadata:
   labels:
     name: event-schema
   name: kubeslice-worker-event-schema-conf
-  namespace: kubeslice-system
+  namespace: {{ .Release.Namespace }}
 


### PR DESCRIPTION
 # Description

  Several templates in the kubeslice-worker chart had `namespace: kubeslice-system` hardcoded instead of using `{{ .Release.Namespace }}`. This broke  installations into any namespace other than `kubeslice-system` — resources would get created in the wrong namespace regardless of where you installed the  chart.

  Fixed all occurrences across five files:
  - `hub-secret.yaml` — `kubeslice-hub` Secret
  - `operator-configmap.yaml` — `kubeslice-manager-config` ConfigMap
  - `operator-deployment.yaml` — `kubeslice-operator` Deployment and `kubeslice-worker-event-schema-conf` ConfigMap
  - `dashboard-rbac.yaml` — `kubeslice-kubernetes-dashboard` ServiceAccount and ClusterRoleBinding subject
  - `kubeslice-postdelete-hook.yaml` — cleanup script `NAMESPACES` variable so post-delete cleanup targets the correct namespace

  Fixes #75 

  ## How Has This Been Tested?

  - Verified zero remaining `kubeslice-system` hardcodes in `charts/kubeslice-worker/templates/` with grep
  - Confirmed all replaced values use `{{ .Release.Namespace }}` consistently with the rest of the chart templates

  - Test case: `helm template kubeslice-worker ./charts/kubeslice-worker -n my-namespace` renders all resources with `namespace: my-namespace`
  - Test case: `helm lint charts/kubeslice-worker/` passes

  ## Checklist:

  * [x] The title of the PR states what changed and the related issues number (used for the release note).
  * [ ] Does this PR requires documentation updates?
  * [ ] I've updated documentation as required by this PR.
  * [x] I have performed a self-review of my own code.
  * [ ] I have commented my code, particularly in hard-to-understand areas.
  * [x] I have tested it for all user roles.
  * [ ] I have added all the required unit test cases.

  ## Does this PR introduce a breaking change for other components like worker-operator?

  No. This only affects installations that were already broken (deploying into a non-default namespace). The default installation namespace `kubeslice-system` is
   unchanged.

  ```release-note
  ```
  
  
  **What was fixed:** 7 hardcoded `kubeslice-system` strings across 5 files, all replaced with `{{ .Release.Namespace }}`. The audit during implementation also caught two additional occurrences in `dashboard-rbac.yaml` and `kubeslice-postdelete-hook.yaml` that weren't in the original issue description — those are included in this PR.
  
 [optional] What gif best describes this PR or how it makes you feel?

![WoW](https://media1.tenor.com/m/IibUHHYqyLYAAAAd/touch-me-just-a-chill-guy.gif)

