### PR TITLE
feat: expose nodeSelector, tolerations, and affinity overrides in w…

### DIFF
--- a/charts/kubeslice-worker/templates/operator-deployment.yaml
+++ b/charts/kubeslice-worker/templates/operator-deployment.yaml
@@ -140,6 +140,18 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 6 }}
       {{- end }}
+      {{- with .Values.operator.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.operator.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.operator.affinity }}
+      affinity:
+        {{- toYaml .Values.operator.affinity | nindent 8 }}
+      {{- else }}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -149,6 +161,7 @@ spec:
                 operator: In
                 values:
                 - gateway
+      {{- end }}
 ---
 apiVersion: v1
 data:

--- a/charts/kubeslice-worker/values.yaml
+++ b/charts/kubeslice-worker/values.yaml
@@ -3,6 +3,9 @@ operator:
   pullPolicy: IfNotPresent
   logLevel: INFO
   tag: 1.4.0
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
 ## Base64 encoded secret values from controller cluster
 controllerSecret:


### PR DESCRIPTION
# Description

The worker operator deployment had a hardcoded `affinity` rule restricting scheduling to`kubeslice.io/node-type: gateway` nodes with no way to override it, and no support for`nodeSelector` or `tolerations` at all. This made it impossible to deploy on  tainted nodes or use custom scheduling rules without forking the chart.

Added `operator.nodeSelector`, `operator.tolerations`, and `operator.affinity` to `values.yaml`and wired them into `operator-deployment.yaml` using the standard `{{- with }}` / `toYaml`pattern. The original gateway node affinity is preserved as the default — setting `operator.affinity` to a non-empty value replaces it entirely.

Fixes #79 

## How Has This Been Tested?

- Default render: `nodeSelector` and `tolerations` blocks are absent; affinity falls through to  the default gateway node affinity.
- Override render: setting `operator.affinity`, `operator.nodeSelector`, or `operator.tolerations`
  in values produces the expected pod spec fields.

- [x] Test case: helm lint passes on kubeslice-worker
- [x] Test case: helm template renders without error
- [ ] Test case: helm lint passes on kubeslice-controller

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit test cases.

## Does this PR introduce a breaking change for other components like worker-operator?

```release-note
NONE
```

## [optional] What gif best describes this PR or how it makes you feel?

![WoW](https://media1.tenor.com/m/IibUHHYqyLYAAAAd/touch-me-just-a-chill-guy.gif)
