### PR TITLE
feat: add required validation for critical values in kubeslice-worker chart

### DIFF
--- a/charts/kubeslice-worker/templates/hub-secret.yaml
+++ b/charts/kubeslice-worker/templates/hub-secret.yaml
@@ -4,6 +4,9 @@ metadata:
   name: kubeslice-hub
   namespace: kubeslice-system 
 {{- with .Values.controllerSecret }}
+{{- $_ := required "controllerSecret.namespace is required" .namespace }}
+{{- $_ := required "controllerSecret.endpoint is required" .endpoint }}
+{{- $_ := required "controllerSecret.token is required" .token }}
 data:
  {{- toYaml . | nindent 2 }}
 {{- end }}

--- a/charts/kubeslice-worker/templates/operator-deployment.yaml
+++ b/charts/kubeslice-worker/templates/operator-deployment.yaml
@@ -55,7 +55,7 @@ spec:
                 name: kubeslice-hub
                 key: namespace
           - name: CLUSTER_NAME
-            value: {{ .Values.cluster.name }}
+            value: {{ required "cluster.name is required" .Values.cluster.name | quote }}
           - name: AVESHA_VL3_ROUTER_IMAGE
             value: "{{ .Values.router.image }}:{{ .Values.router.tag }}"
           - name: AVESHA_VL3_ROUTER_PULLPOLICY
@@ -65,7 +65,7 @@ spec:
           - name: AVESHA_VL3_SIDECAR_IMAGE_PULLPOLICY
             value: {{ .Values.routerSidecar.pullPolicy }}
           - name: CLUSTER_ENDPOINT
-            value: "{{ .Values.cluster.endpoint }}"
+            value: {{ required "cluster.endpoint is required" .Values.cluster.endpoint | quote }}
           - name: AVESHA_GW_SIDECAR_IMAGE
             value: '{{ .Values.gateway.image }}:{{ .Values.gateway.tag }}'
           - name: AVESHA_GW_SIDECAR_IMAGE_PULLPOLICY


### PR DESCRIPTION
# Description

The `kubeslice-worker` chart had no validation on values that are essential for the operator to function — `cluster.name`, `cluster.endpoint`, `controllerSecret.namespace`, `controllerSecret.endpoint`, and `controllerSecret.token`. Installing without these set would succeed silently and only fail at runtime with cryptic errors.

Added Helm `required` validation:
- `cluster.name` and `cluster.endpoint` in `operator-deployment.yaml` via inline `required` with `| quote`
- `controllerSecret.namespace`, `.endpoint`, `.token` in `hub-secret.yaml` using  `{{- $_ := required ... }}` inside the existing `with` block (validates without emitting output)

The controller chart already uses this pattern for its critical values.

Fixes #81 

## How Has This Been Tested?

- `helm template` with all required values set renders correctly.
- `helm template` without `cluster.name` fails immediately with `"cluster.name is required"`.
- `helm template` without `controllerSecret.token` fails immediately with `"controllerSecret.token is required"`.

- [x] Test case: helm lint passes on kubeslice-worker
- [x] Test case: helm template renders without error
- [ ] Test case: helm lint passes on kubeslice-controller

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit test cases.

## Does this PR introduce a breaking change for other components like worker-operator?

```release-note
NONE
```

## [optional] What gif best describes this PR or how it makes you feel?

![WoW](https://media1.tenor.com/m/IibUHHYqyLYAAAAd/touch-me-just-a-chill-guy.gif)
