### PR TITLE
feat(): add values.schema.json to kubeslice-controller and kubeslice-worker charts

### DIFF
--- a/charts/kubeslice-controller/values.schema.json
+++ b/charts/kubeslice-controller/values.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "kubeslice": {
+      "type": "object",
+      "required": ["controller"],
+      "properties": {
+        "rbacproxy": {
+          "type": "object",
+          "properties": {
+            "image": { "type": "string" },
+            "tag": { "type": "string" }
+          },
+          "additionalProperties": false
+        },
+        "controller": {
+          "type": "object",
+          "required": ["logLevel", "rbacResourcePrefix", "projectnsPrefix"],
+          "properties": {
+            "logLevel": { "type": "string" },
+            "rbacResourcePrefix": { "type": "string" },
+            "projectnsPrefix": { "type": "string" },
+            "endpoint": { "type": ["string", "null"] },
+            "image": { "type": "string" },
+            "tag": { "type": "string" },
+            "pullPolicy": {
+              "type": "string",
+              "enum": ["Always", "IfNotPresent", "Never"]
+            }
+          },
+          "additionalProperties": false
+        },
+        "ovpnJob": {
+          "type": "object",
+          "properties": {
+            "image": { "type": "string" },
+            "tag": { "type": "string" }
+          },
+          "additionalProperties": false
+        },
+        "events": {
+          "type": "object",
+          "properties": {
+            "disabled": { "type": "boolean" }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/charts/kubeslice-worker/values.schema.json
+++ b/charts/kubeslice-worker/values.schema.json
@@ -1,0 +1,183 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "operator": {
+      "type": "object",
+      "properties": {
+        "image": { "type": "string" },
+        "pullPolicy": {
+          "type": "string",
+          "enum": ["Always", "IfNotPresent", "Never"]
+        },
+        "logLevel": { "type": "string" },
+        "tag": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "controllerSecret": {
+      "type": "object",
+      "properties": {
+        "namespace": { "type": ["string", "null"] },
+        "endpoint": { "type": ["string", "null"] },
+        "ca.crt": { "type": ["string", "null"] },
+        "token": { "type": ["string", "null"] }
+      },
+      "additionalProperties": false
+    },
+    "cluster": {
+      "type": "object",
+      "properties": {
+        "name": { "type": ["string", "null"] },
+        "nodeIp": { "type": ["string", "null"] },
+        "endpoint": { "type": ["string", "null"] }
+      },
+      "additionalProperties": false
+    },
+    "router": {
+      "type": "object",
+      "properties": {
+        "image": { "type": "string" },
+        "tag": { "type": "string" },
+        "pullPolicy": {
+          "type": "string",
+          "enum": ["Always", "IfNotPresent", "Never"]
+        }
+      },
+      "additionalProperties": false
+    },
+    "routerSidecar": {
+      "type": "object",
+      "properties": {
+        "image": { "type": "string" },
+        "tag": { "type": "string" },
+        "pullPolicy": {
+          "type": "string",
+          "enum": ["Always", "IfNotPresent", "Never"]
+        }
+      },
+      "additionalProperties": false
+    },
+    "gateway": {
+      "type": "object",
+      "properties": {
+        "image": { "type": "string" },
+        "tag": { "type": "string" },
+        "pullPolicy": {
+          "type": "string",
+          "enum": ["Always", "IfNotPresent", "Never"]
+        },
+        "logLevel": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "gatewayEdge": {
+      "type": "object",
+      "properties": {
+        "image": { "type": "string" },
+        "tag": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "openvpn": {
+      "type": "object",
+      "properties": {
+        "server": {
+          "type": "object",
+          "properties": {
+            "image": { "type": "string" },
+            "tag": { "type": "string" },
+            "pullPolicy": {
+              "type": "string",
+              "enum": ["Always", "IfNotPresent", "Never"]
+            }
+          },
+          "additionalProperties": false
+        },
+        "client": {
+          "type": "object",
+          "properties": {
+            "image": { "type": "string" },
+            "tag": { "type": "string" },
+            "pullPolicy": {
+              "type": "string",
+              "enum": ["Always", "IfNotPresent", "Never"]
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "dns": {
+      "type": "object",
+      "properties": {
+        "image": { "type": "string" },
+        "tag": { "type": "string" },
+        "pullPolicy": {
+          "type": "string",
+          "enum": ["Always", "IfNotPresent", "Never"]
+        }
+      },
+      "additionalProperties": false
+    },
+    "workerInstaller": {
+      "type": "object",
+      "properties": {
+        "image": { "type": "string" },
+        "tag": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "jaeger": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" }
+      },
+      "additionalProperties": false
+    },
+    "events": {
+      "type": "object",
+      "properties": {
+        "disabled": { "type": "boolean" }
+      },
+      "additionalProperties": false
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" }
+        },
+        "required": ["name"],
+        "additionalProperties": false
+      }
+    },
+    "controllerNamespace": { "type": "string" },
+    "global": {
+      "type": "object",
+      "properties": {
+        "imageRegistry": { "type": "string" },
+        "profile": {
+          "type": "object",
+          "properties": {
+            "openshift": { "type": "boolean" }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "kubesliceNetworking": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" }
+      },
+      "additionalProperties": false
+    },
+    "nsm": {
+      "type": "object"
+    }
+  }
+}


### PR DESCRIPTION
# Description

Adds `values.schema.json` to both `kubeslice-controller` and `kubeslice-worker` charts to enforce input validation at `helm install`/`helm upgrade` time.

Without schema validation, Helm silently accepts wrong types, misspelled keys, and invalid enum values — errors that only surface at runtime as cryptic operator failures. Both charts previously had zero input validation at the Helm layer.

**What the schemas enforce:**
- **Type constraints** — prevents `cluster.name: 123` (integer) or `jaeger.enabled: "false"` (string) being silently accepted
- **Enum constraints** — all `pullPolicy` fields (7 in worker, 1 in controller) are restricted to `Always | IfNotPresent | Never`
- **Required fields** — `kubeslice.controller.logLevel`, `rbacResourcePrefix`, `projectnsPrefix` must be non-empty (controller); schema complements the existing `required()` template calls in both charts
- **Misspelled key detection** — `additionalProperties: false` on well-known objects catches `operator.imagepullpolicy` instead of `operator.pullPolicy`, `kubeslice.controller.loglevel` instead of `logLevel`, etc.

The worker schema leaves `nsm` open (`additionalProperties` not restricted) to avoid conflicting with NSM subchart values that are passed through the parent chart.

Default `values.yaml` for both charts satisfies the schema — no breaking change for existing installs.

Fixes #85 

## How Has This Been Tested?

Validated with `jsonschema` (Python):
- Default `values.yaml` passes schema for both charts
- Schema correctly rejects: wrong type (`cluster.name: 123`), wrong enum case (`pullPolicy: always`), bool-as-string (`jaeger.enabled: "false"`), misspelled key (`operator.imagepullpolicy`), unknown controller key (`kubeslice.controller.loglevel`)

- [x] Test case: helm lint passes on kubeslice-controller
- [x] Test case: helm lint passes on kubeslice-worker
- [x] Test case: helm template renders without error

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit test cases.

## Does this PR introduce a breaking change for other components like worker-operator?

```release-note
feat: add JSON Schema validation for kubeslice-controller and kubeslice-worker chart values
```

## [optional] What gif best describes this PR or how it makes you feel?

![WoW](https://media1.tenor.com/m/IibUHHYqyLYAAAAd/touch-me-just-a-chill-guy.gif)
