### PR TITLE
feat: expose scheduling overrides for kubeslice-controller deployment

### DIFF
--- a/charts/kubeslice-controller/templates/controller-deployment.yaml
+++ b/charts/kubeslice-controller/templates/controller-deployment.yaml
@@ -16,6 +16,9 @@ spec:
         kubectl.kubernetes.io/default-container: manager
         prometheus.io/port: "18080"
         prometheus.io/scrape: "true"
+        {{- with .Values.kubeslice.controller.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels:
         control-plane: controller-manager
     spec:
@@ -85,6 +88,21 @@ spec:
         runAsNonRoot: true
       serviceAccountName: kubeslice-controller-controller-manager
       terminationGracePeriodSeconds: 10
+      {{- with .Values.kubeslice.controller.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.kubeslice.controller.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.kubeslice.controller.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.kubeslice.controller.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
       volumes:
         - name: kubeslice-controller-event-schema-conf
           configMap:

--- a/charts/kubeslice-controller/values.schema.json
+++ b/charts/kubeslice-controller/values.schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "kubeslice": {
+      "type": "object",
+      "required": ["controller"],
+      "properties": {
+        "rbacproxy": {
+          "type": "object",
+          "properties": {
+            "image": { "type": "string" },
+            "tag": { "type": "string" }
+          },
+          "additionalProperties": false
+        },
+        "controller": {
+          "type": "object",
+          "required": ["logLevel", "rbacResourcePrefix", "projectnsPrefix"],
+          "properties": {
+            "logLevel": { "type": "string" },
+            "rbacResourcePrefix": { "type": "string" },
+            "projectnsPrefix": { "type": "string" },
+            "endpoint": { "type": ["string", "null"] },
+            "image": { "type": "string" },
+            "tag": { "type": "string" },
+            "pullPolicy": {
+              "type": "string",
+              "enum": ["Always", "IfNotPresent", "Never"]
+            },
+            "nodeSelector": { "type": "object" },
+            "tolerations": { "type": "array" },
+            "affinity": { "type": "object" },
+            "podAnnotations": { "type": "object" },
+            "priorityClassName": { "type": "string" }
+          },
+          "additionalProperties": false
+        },
+        "ovpnJob": {
+          "type": "object",
+          "properties": {
+            "image": { "type": "string" },
+            "tag": { "type": "string" }
+          },
+          "additionalProperties": false
+        },
+        "events": {
+          "type": "object",
+          "properties": {
+            "disabled": { "type": "boolean" }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/charts/kubeslice-controller/values.yaml
+++ b/charts/kubeslice-controller/values.yaml
@@ -14,6 +14,11 @@ kubeslice:
     image: docker.io/aveshasystems/kubeslice-controller
     tag: 1.4.0
     pullPolicy: IfNotPresent
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+    podAnnotations: {}
+    priorityClassName: ""
   ovpnJob:
     image: aveshasystems/gateway-certs-generator
     tag: 0.5.0


### PR DESCRIPTION
# Description

Exposes `nodeSelector`, `tolerations`, `affinity`, `podAnnotations`, and `priorityClassName` for the `kubeslice-controller` deployment via `values.yaml`.

Previously the controller pod had no scheduling fields at all — it would schedule on any available node with no way to restrict placement, add tolerations for tainted nodes, or attach custom annotations. The only escape was forking the chart.

**Changes:**
- `values.yaml` — adds five new fields under `kubeslice.controller` with safe empty defaults  (`nodeSelector: {}`, `tolerations: []`, `affinity: {}`, `podAnnotations: {}`, `priorityClassName: ""`)
- `controller-deployment.yaml` — wires the new values into the pod spec using `{{- with }}`  blocks (fields render only when non-empty, no output change for existing installs).  `podAnnotations` merges with the existing hardcoded prometheus annotations.
- `values.schema.json` — adds type constraints for all five new fields

No breaking change: all defaults are empty so existing installs render identically.

Fixes #87

## How Has This Been Tested?

- Default `values.yaml` satisfies the updated schema (validated with `jsonschema`)
- Template YAML structure validated (2 documents parse cleanly after Helm expression stripping)
- All 5 new template blocks confirmed present in rendered output

- [x] Test case: helm lint passes on kubeslice-controller
- [x] Test case: helm template renders without error
- [x] Test case: helm template with nodeSelector/tolerations set renders correctly

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit test cases.

## Does this PR introduce a breaking change for other components like worker-operator?

```release-note
feat: expose nodeSelector, tolerations, affinity, podAnnotations, and priorityClassName for kubeslice-controller deployment
```

## [optional] What gif best describes this PR or how it makes you feel?

![WoW](https://media1.tenor.com/m/IibUHHYqyLYAAAAd/touch-me-just-a-chill-guy.gif)
