### PR TITLE
 fix: pass actual pull secret name in IMAGE_PULL_SECRET_NAME env var

### DIFF
--- a/charts/kubeslice-worker/templates/operator-deployment.yaml
+++ b/charts/kubeslice-worker/templates/operator-deployment.yaml
@@ -85,7 +85,7 @@ spec:
 
           {{- if .Values.imagePullSecrets }}
           - name: IMAGE_PULL_SECRET_NAME
-            value: ""
+            value: {{ (index .Values.imagePullSecrets 0).name | quote }}
           {{- end }}
           
         livenessProbe:


### PR DESCRIPTION
# Description

When `imagePullSecrets` is configured, the `IMAGE_PULL_SECRET_NAME` environment variable in the worker operator deployment was hardcoded to an empty string `""`. The operator binary reads this env var to attach the pull secret to the dynamic sidecar pods it creates (VPN, gateway sidecar, etc.), so an empty value silently breaks private registry support , the operator pod itself starts fine but any sidecar pod it spawns cannot pull images.

Changed the value from `""` to `{{ (index .Values.imagePullSecrets 0).name | quote }}` so the operator receives the actual secret name.

Fixes #90 

## How Has This Been Tested?

- Verified `IMAGE_PULL_SECRET_NAME` now renders the first pull secret name when `imagePullSecrets` is set
- Confirmed the block still renders nothing when `imagePullSecrets` is empty (condition unchanged)
- Validated YAML structure of `operator-deployment.yaml`

- [x] Test case: helm lint passes on kubeslice-worker
- [x] Test case: helm template renders without error with `--set imagePullSecrets[0].name=my-secret`
- [ ] Test case: helm lint passes on kubeslice-controller

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit test cases.

## Does this PR introduce a breaking change for other components like worker-operator?

```release-note
fix: IMAGE_PULL_SECRET_NAME env var now correctly passes pull secret name to worker operator
```

## [optional] What gif best describes this PR or how it makes you feel?

![WoW](https://media1.tenor.com/m/IibUHHYqyLYAAAAd/touch-me-just-a-chill-guy.gif)
