### PR TITLE
fix: replace deprecated kube-rbac-proxy image registry (Fixes #93)

### DIFF
--- a/charts/kubeslice-controller/values.yaml
+++ b/charts/kubeslice-controller/values.yaml
@@ -4,7 +4,7 @@
 
 kubeslice:
   rbacproxy:
-    image: gcr.io/kubebuilder/kube-rbac-proxy
+    image: quay.io/brancz/kube-rbac-proxy
     tag: v0.8.0
   controller:
     logLevel: debug

--- a/charts/kubeslice-worker/templates/operator-deployment.yaml
+++ b/charts/kubeslice-worker/templates/operator-deployment.yaml
@@ -27,7 +27,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.8.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443


### PR DESCRIPTION
# Description

Fixes #93

Updated kube-rbac-proxy image from deprecated `gcr.io/kubebuilder/kube-rbac-proxy` to `quay.io/brancz/kube-rbac-proxy` in helm charts.

## How Has This Been Tested?

* Verified the image reference is updated in `charts/kubeslice-controller/values.yaml`
* Verified the image reference is updated in `charts/kubeslice-worker/templates/operator-deployment.yaml`

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] Does this PR requires documentation updates? No
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit test cases.

## Does this PR introduce a breaking change for other components like worker-operator?

No

## Release note

```release-note
NONE
``` 