### PR TITLE
fix: replace deprecated gcr.io/kubebuilder kube-rbac-proxy registry

### DIFF
--- a/charts/kubeslice-controller/values.yaml
+++ b/charts/kubeslice-controller/values.yaml
@@ -4,7 +4,7 @@
 
 kubeslice:
   rbacproxy:
-    image: gcr.io/kubebuilder/kube-rbac-proxy
+    image: quay.io/brancz/kube-rbac-proxy
     tag: v0.8.0
   controller:
     logLevel: debug

--- a/charts/kubeslice-worker/templates/operator-deployment.yaml
+++ b/charts/kubeslice-worker/templates/operator-deployment.yaml
@@ -27,7 +27,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.8.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443


### PR DESCRIPTION
## What this fixes

The `kube-rbac-proxy` image in the Helm charts references `gcr.io/kubebuilder/kube-rbac-proxy`, which is deprecated and no longer maintained. This can cause deployment failures if/when that registry becomes unavailable.

## Changes

- `charts/kubeslice-controller/values.yaml`: updated `rbacproxy.image` to `quay.io/brancz/kube-rbac-proxy`
- `charts/kubeslice-worker/templates/operator-deployment.yaml`: updated the `kube-rbac-proxy` container image to `quay.io/brancz/kube-rbac-proxy`

Verified the `v0.8.0` tag exists on the new registry (multi-arch manifest, 5 child images) before making the change.

Addresses #93.